### PR TITLE
Fix concat issue

### DIFF
--- a/minigotchi-ESP32/pwnagotchi.cpp
+++ b/minigotchi-ESP32/pwnagotchi.cpp
@@ -170,8 +170,6 @@ void Pwnagotchi::pwnagotchiCallback(void *buf,
         for (int i = 38; i < len; i++) {
           if (isAscii(snifferPacket->payload[i])) {
             essid.concat((char)snifferPacket->payload[i]);
-          } else {
-            essid.concat("");
           }
         }
 

--- a/minigotchi-ESP32/pwnagotchi.cpp
+++ b/minigotchi-ESP32/pwnagotchi.cpp
@@ -171,7 +171,7 @@ void Pwnagotchi::pwnagotchiCallback(void *buf,
           if (isAscii(snifferPacket->payload[i])) {
             essid.concat((char)snifferPacket->payload[i]);
           } else {
-            essid.concat("?");
+            essid.concat("");
           }
         }
 


### PR DESCRIPTION
When using `?` for the concat I get a parsing issue:

```
(^-^) Pwnagotchi detected!
 
(^-^) RSSI: -45
(^-^) Channel: 7
(^-^) BSSID: XX:XX:XX:XX:XX
(^-^) ESSID: {"pal":true,"name":"Palnagotchi","face":"(O__O)","epoch":1,"grid_version":"1.10.3","identity":"","pwnd_run":0,"pwnd_tot":0,"session_id":"XX:XX:XX:XX:XX","timestamp":0,"uptime":0,"version":??"1.8.4","policy":{"advertise":true,"bond_encounters_factor":20000,"bored_num_epochs":0,"sad_num_epochs":0,"excited_num_epochs":9999}}
 
(X-X) Could not parse Pwnagotchi json: 
(X-X) InvalidInput
```

(See the two questionmarks after `"version"`)

When using an empty string to concat, minigitchi can perfectly parse the JSON. You can see an example here: https://github.com/dj1ch/minigotchi-ESP32/issues/107

I tested the change also with a pwnagotchi!